### PR TITLE
Added self-correction punch in/out with dual timestamps

### DIFF
--- a/app/src/main/java/com/technikh/employeeattendancetracking/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/data/database/AppDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.technikh.employeeattendancetracking.data.database.converters.Converters
 import com.technikh.employeeattendancetracking.data.database.daos.AttendanceDao
 import com.technikh.employeeattendancetracking.data.database.daos.EmployeeDao
@@ -16,7 +18,7 @@ import com.technikh.employeeattendancetracking.data.database.entities.OfficeWork
 
 @Database(
     entities = [Employee::class, AttendanceRecord::class, OfficeWorkReason::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -29,13 +31,54 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                            CREATE TABLE attendance_records_new (
+                                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                                employeeId TEXT NOT NULL,
+                                punchType TEXT NOT NULL,
+                                systemTimeMillis INTEGER NOT NULL,
+                                employeeTimeMillis INTEGER NOT NULL,
+                                isManuallyEdited INTEGER NOT NULL,
+                                reason TEXT,
+                                workReason TEXT,
+                                isOfficeWork INTEGER NOT NULL,
+                                selfiePath TEXT
+                            )
+                        """
+                )
+                database.execSQL(
+                    """
+                            INSERT INTO attendance_records_new (
+                                id, employeeId, punchType,
+                                systemTimeMillis, employeeTimeMillis, isManuallyEdited,
+                                reason, workReason, isOfficeWork, selfiePath
+                            )
+                            SELECT
+                                id, employeeId, punchType,
+                                timestamp, timestamp, 0,
+                                reason, workReason, isOfficeWork, selfiePath
+                            FROM attendance_records
+                        """
+                )
+                database.execSQL(
+                    "DROP TABLE attendance_records"
+                )
+                database.execSQL(
+                    "ALTER TABLE attendance_records_new RENAME TO attendance_records" 
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     AppDatabase::class.java,
                     "attendance_db"
-                ).build()
+                ).addMigrations(MIGRATION_1_2).build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/data/database/daos/AttendanceDao.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/data/database/daos/AttendanceDao.kt
@@ -14,46 +14,46 @@ interface AttendanceDao {
     @Query("SELECT * FROM employees")
     suspend fun getAllEmployeesList(): List<Employee>
 
-    @Query("SELECT * FROM attendance_records ORDER BY timestamp DESC")
+    @Query("SELECT * FROM attendance_records ORDER BY employeeTimeMillis DESC")
     suspend fun getAllRecordsList(): List<AttendanceRecord>
 
-    @Query("SELECT * FROM attendance_records WHERE employeeId = :empId ORDER BY timestamp DESC LIMIT 1")
+    @Query("SELECT * FROM attendance_records WHERE employeeId = :empId ORDER BY employeeTimeMillis DESC LIMIT 1")
     fun getLastRecordFlow(empId: String): Flow<AttendanceRecord?>
 
-    @Query("SELECT * FROM attendance_records WHERE employeeId = :empId ORDER BY timestamp DESC LIMIT 1")
+    @Query("SELECT * FROM attendance_records WHERE employeeId = :empId ORDER BY employeeTimeMillis DESC LIMIT 1")
     suspend fun getLastRecord(empId: String): AttendanceRecord?
 
-    @Query("SELECT * FROM attendance_records WHERE timestamp >= :startOfDay ORDER BY timestamp DESC")
+    @Query("SELECT * FROM attendance_records WHERE employeeTimeMillis >= :startOfDay ORDER BY employeeTimeMillis DESC")
     fun getTodayAttendance(startOfDay: Long): Flow<List<AttendanceRecord>>
 
-    @Query("SELECT * FROM attendance_records ORDER BY timestamp DESC")
+    @Query("SELECT * FROM attendance_records ORDER BY employeeTimeMillis DESC")
     fun getAllRecordsFlow(): Flow<List<AttendanceRecord>>
 
     @Insert
     suspend fun insert(record: AttendanceRecord)
 
-    @Query("SELECT * FROM attendance_records WHERE employeeId = :employeeId ORDER BY timestamp DESC")
+    @Query("SELECT * FROM attendance_records WHERE employeeId = :employeeId ORDER BY employeeTimeMillis DESC")
     suspend fun getAttendanceByEmployee(employeeId: String): List<AttendanceRecord>
 
-    @Query("SELECT * FROM attendance_records WHERE employeeId = :employeeId ORDER BY timestamp DESC")
+    @Query("SELECT * FROM attendance_records WHERE employeeId = :employeeId ORDER BY employeeTimeMillis DESC")
     fun getDailyAttendance(employeeId: String): Flow<List<AttendanceRecord>>
 
     @Query("""
         SELECT 
-            date(timestamp/1000, 'unixepoch') as day,
+            date(employeeTimeMillis/1000, 'unixepoch') as day,
             SUM(CASE WHEN punchType = 'OUT' AND isOfficeWork = 1 THEN 
-                (timestamp - (SELECT timestamp FROM attendance_records r2 
+                (employeeTimeMillis - (SELECT employeeTimeMillis FROM attendance_records r2 
                               WHERE r2.employeeId = r1.employeeId 
-                              AND date(r2.timestamp/1000, 'unixepoch') = date(r1.timestamp/1000, 'unixepoch')
+                              AND date(r2.employeeTimeMillis/1000, 'unixepoch') = date(r1.employeeTimeMillis/1000, 'unixepoch')
                               AND r2.punchType = 'IN' 
                               AND r2.id < r1.id
-                              ORDER BY r2.timestamp DESC LIMIT 1)
+                              ORDER BY r2.employeeTimeMillis DESC LIMIT 1)
                 ) 
                 ELSE 0 END) / (1000 * 60 * 60.0) as officeHours
         FROM attendance_records r1
         WHERE employeeId = :employeeId 
-        AND strftime('%Y-%m', datetime(timestamp/1000, 'unixepoch')) = :monthYear
-        GROUP BY date(timestamp/1000, 'unixepoch')
+        AND strftime('%Y-%m', datetime(employeeTimeMillis/1000, 'unixepoch')) = :monthYear
+        GROUP BY date(employeeTimeMillis/1000, 'unixepoch')
     """)
     suspend fun getMonthlyOfficeHours(employeeId: String, monthYear: String): List<DayOfficeHours>
 }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/data/database/entities/AttendanceRecord.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/data/database/entities/AttendanceRecord.kt
@@ -9,7 +9,11 @@ data class AttendanceRecord(
     val id: Int = 0,
     val employeeId: String,
     val punchType: String, // "IN" or "OUT"
-    val timestamp: Long = System.currentTimeMillis(),
+
+    val systemTimeMillis: Long = System.currentTimeMillis(),
+    val employeeTimeMillis: Long = systemTimeMillis,
+    val isManuallyEdited: Boolean = false,
+
     val reason: String? = null,
     val workReason: String? = null,
     val isOfficeWork: Boolean = false,

--- a/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/login/LoginScreen.kt
@@ -196,7 +196,7 @@ fun LoginScreen(
 
                 items(timeline) { record ->
                     val empName = employees.find { it.employeeId == record.employeeId }?.name ?: "Unknown"
-                    val time = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(record.timestamp))
+                    val time = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(record.systemTimeMillis))
                     val color = if (record.punchType == "IN") Color(0xFFE8F5E9) else Color(0xFFFFEBEE)
 
                     Card(

--- a/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/reports/GlobalReportsScreen.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/reports/GlobalReportsScreen.kt
@@ -225,19 +225,36 @@ fun GlobalReportsScreen(
 
 @Composable
 fun GlobalLogItem(record: AttendanceRecord, empName: String) {
-    val time = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(record.timestamp))
-    Card(Modifier.fillMaxWidth().padding(vertical = 4.dp), elevation = CardDefaults.cardElevation(2.dp)) {
+    val timeFormat = SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault())
+    val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
+
+    Card(
+        Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
         Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
             Column(Modifier.weight(1f)) {
                 Text(empName, fontWeight = FontWeight.Bold)
-                Row {
-                    Text(record.punchType, color = if(record.punchType == "IN") Color(0xFF2E7D32) else Color(0xFFC62828), fontWeight = FontWeight.Bold)
-                    Spacer(Modifier.width(8.dp))
-                    Text(time)
+                Text(
+                    text = "Recorded on ${dateFormat.format(Date(record.systemTimeMillis))} at ${timeFormat.format(Date(record.systemTimeMillis))}",
+                    color = if (record.punchType == "IN") Color(0xFF2E7D32) else Color(0xFFC62828),
+                    fontWeight = FontWeight.Bold
+                )
+                if (record.isManuallyEdited) {
+                    Text(
+                        "Recorded at ${timeFormat.format(Date(record.systemTimeMillis))}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
                 }
             }
+
             if (record.punchType == "OUT" && record.reason != null) {
-                Text(record.reason, style = MaterialTheme.typography.bodySmall, fontStyle = FontStyle.Italic)
+                Text(
+                    record.reason,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontStyle = FontStyle.Italic
+                )
             }
         }
     }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/reports/ReportsDashboard.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/reports/ReportsDashboard.kt
@@ -114,10 +114,23 @@ fun DailyReportView(reports: List<DailyAttendance>) {
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+                            val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
                             Text(
-                                text = timeFormat.format(Date(record.timestamp)),
+                                text = timeFormat.format(Date(record.employeeTimeMillis)),
                                 color = if (record.punchType == "IN") Color(0xFF4CAF50) else Color(0xFFF44336)
                             )
+                            if (record.isManuallyEdited) {
+                                Text(
+                                    text = "Recorded on ${dateFormat.format(Date(record.systemTimeMillis))} at ${timeFormat.format(Date(record.systemTimeMillis))}",
+                                    fontSize = 12.sp,
+                                    color = Color.Gray
+                                )
+                                Text(
+                                    text = "Self-corrected",
+                                    fontSize = 11.sp,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
                             Text(record.punchType)
                             if (record.reason != null) Text(record.reason, fontStyle = FontStyle.Italic)
                         }
@@ -181,10 +194,10 @@ fun MonthlyReportView(monthlyData: List<DayOfficeHours>) {
 fun calculateDailyHoursLocal(records: List<AttendanceRecord>): Double {
     var totalHours = 0.0
     var lastPunchIn: Long? = null
-    records.sortedBy { it.timestamp }.forEach { record ->
-        if (record.punchType == "IN") lastPunchIn = record.timestamp
+    records.sortedBy { it.employeeTimeMillis }.forEach { record ->
+        if (record.punchType == "IN") lastPunchIn = record.employeeTimeMillis
         else if (record.punchType == "OUT" && lastPunchIn != null) {
-            totalHours += (record.timestamp - lastPunchIn!!) / (1000.0 * 60 * 60)
+            totalHours += (record.employeeTimeMillis - lastPunchIn!!) / (1000.0 * 60 * 60)
             lastPunchIn = null
         }
     }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/reports/ReportsDashboardV2.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/reports/ReportsDashboardV2.kt
@@ -238,12 +238,25 @@ fun DailySingleDayView(records: List<AttendanceRecord>, showSelfies: Boolean) {
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
                         val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+                        val dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.getDefault())
                         Text(
-                            text = timeFormat.format(Date(record.timestamp)),
+                            text = timeFormat.format(Date(record.employeeTimeMillis)),
                             color = if (record.punchType == "IN") Color(0xFF4CAF50) else Color(0xFFF44336),
                             fontWeight = FontWeight.Bold,
                             fontSize = 18.sp
                         )
+                        if (record.isManuallyEdited) {
+                            Text(
+                                text = "Recorded on ${dateFormat.format(Date(record.systemTimeMillis))} at ${timeFormat.format(Date(record.systemTimeMillis))}",
+                                fontSize = 12.sp,
+                                color = Color.Gray
+                            )
+                            Text(
+                                text = "Self-corrected",
+                                fontSize = 11.sp,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
                         Text(record.punchType, fontWeight = FontWeight.SemiBold)
 
                         if (record.punchType == "OUT") {
@@ -321,10 +334,10 @@ fun MonthlyReportViewV2(monthlyData: List<DayOfficeHours>) {
 fun calculateDailyHoursLocalV2(records: List<AttendanceRecord>): Double {
     var totalHours = 0.0
     var lastPunchIn: Long? = null
-    records.sortedBy { it.timestamp }.forEach { record ->
-        if (record.punchType == "IN") lastPunchIn = record.timestamp
+    records.sortedBy { it.employeeTimeMillis }.forEach { record ->
+        if (record.punchType == "IN") lastPunchIn = record.employeeTimeMillis
         else if (record.punchType == "OUT" && lastPunchIn != null) {
-            totalHours += (record.timestamp - lastPunchIn!!) / (1000.0 * 60 * 60)
+            totalHours += (record.employeeTimeMillis - lastPunchIn!!) / (1000.0 * 60 * 60)
             lastPunchIn = null
         }
     }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/ui/screens/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ fun SettingsScreen(onBack: () -> Unit) {
 
         var isPassEnabled by remember { mutableStateOf(settingsManager.isPasswordFeatureEnabled) }
         var isPreviewEnabled by remember { mutableStateOf(settingsManager.showCameraPreview) }
+        var allowSelfCorrection by remember { mutableStateOf(settingsManager.allowSelfCorrection) }
         var maxEmp by remember { mutableStateOf(settingsManager.maxHomeEmployees.toString()) }
         var newAdminPass by remember { mutableStateOf("") }
 
@@ -80,6 +81,15 @@ fun SettingsScreen(onBack: () -> Unit) {
             }
             Divider(Modifier.padding(vertical = 8.dp))
 
+
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text("Allow Employee Self-Correction")
+                Switch(checked = allowSelfCorrection, onCheckedChange = {
+                    allowSelfCorrection = it
+                    settingsManager.allowSelfCorrection = it
+                })
+            }
+            Divider(Modifier.padding(vertical = 8.dp))
 
             OutlinedTextField(
                 value = maxEmp,

--- a/app/src/main/java/com/technikh/employeeattendancetracking/utils/AttendanceUtils.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/utils/AttendanceUtils.kt
@@ -9,11 +9,11 @@ object AttendanceUtils {
         var totalHours = 0.0
         var lastPunchIn: Long? = null
 
-        records.sortedBy { it.timestamp }.forEach { record ->
+        records.sortedBy { it.employeeTimeMillis }.forEach { record ->
             when (record.punchType) {
-                "IN" -> lastPunchIn = record.timestamp
+                "IN" -> lastPunchIn = record.employeeTimeMillis
                 "OUT" -> lastPunchIn?.let { punchIn ->
-                    val duration = (record.timestamp - punchIn) / (1000.0 * 60 * 60)
+                    val duration = (record.employeeTimeMillis - punchIn) / (1000.0 * 60 * 60)
                     if (record.isOfficeWork) {
                         totalHours += duration
                     }
@@ -27,11 +27,11 @@ object AttendanceUtils {
 
     fun groupRecordsByDate(records: List<AttendanceRecord>): List<DailyAttendance> {
         return records.groupBy {
-            SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(it.timestamp))
+            SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(it.employeeTimeMillis))
         }.map { (date, dayRecords) ->
             DailyAttendance(
                 date = date,
-                records = dayRecords.sortedByDescending { it.timestamp }
+                records = dayRecords.sortedByDescending { it.employeeTimeMillis }
             )
         }.sortedByDescending { it.date }
     }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/utils/CsvUtils.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/utils/CsvUtils.kt
@@ -35,8 +35,8 @@ object CsvUtils {
             val timeFormat = SimpleDateFormat("HH:mm:ss", Locale.getDefault())
 
             records.forEach { record ->
-                val date = dateFormat.format(Date(record.timestamp))
-                val time = timeFormat.format(Date(record.timestamp))
+                val date = dateFormat.format(Date(record.employeeTimeMillis))
+                val time = timeFormat.format(Date(record.employeeTimeMillis))
 
                 val cleanReason = record.reason?.replace(",", " ") ?: ""
                 val cleanWorkReason = record.workReason?.replace(",", " ") ?: ""

--- a/app/src/main/java/com/technikh/employeeattendancetracking/utils/SettingsManager.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/utils/SettingsManager.kt
@@ -21,4 +21,8 @@ class SettingsManager(context: Context) {
     var maxHomeEmployees: Int
         get() = prefs.getInt("max_home_employees", 5)
         set(value) = prefs.edit().putInt("max_home_employees", value).apply()
+
+    var allowSelfCorrection: Boolean
+        get() = prefs.getBoolean("allow_self_correction", false)
+        set(value) = prefs.edit().putBoolean("allow_self_correction", value).apply()
 }

--- a/app/src/main/java/com/technikh/employeeattendancetracking/viewmodel/AttendanceViewModel.kt
+++ b/app/src/main/java/com/technikh/employeeattendancetracking/viewmodel/AttendanceViewModel.kt
@@ -51,7 +51,7 @@ class AttendanceViewModel(
             attendanceDao.getDailyAttendance(employeeId).collect { records ->
                 // This logic transforms the "Raw List" into "Grouped by Date"
                 val groupedData = records.groupBy { record ->
-                    SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(record.timestamp))
+                    SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date(record.systemTimeMillis))
                 }.map { (date, dayRecords) ->
                     DailyAttendance(date, dayRecords)
                 }


### PR DESCRIPTION
### Summary
Implemented employee self-correction for punch in/out.
Employees who forget to punch can now select a past date & time, while the system continues to record the actual system time for transparency and audit purposes.


### Key Features
**1. Admin-controlled self-correction**

- Added a new setting: “Allow employee self-correction”
- When enabled, employees can manually select punch date & time
- When disabled, punch behavior remains unchanged (system time only)

**2. Date & time picker before punch**
- Date & time picker is shown before any punch is recorded
- Default value = current system date & time
- Punch is recorded only after date/time is confirmed

**3. Dual timestamp storage** 
- Each attendance record now stores:
- System Time → when the punch was actually recorded
- Employee Time → user-selected time (if self-corrected)


### Database changes & migration 
**Schema update:-**

Replaced legacy timestamp with:

- systemTimeMillis
- employeeTimeMillis 
- isManuallyEdited

Migration strategy

- Uses recreate-and-copy migration 

- Migration recreates attendance_records to replace legacy timestamp with dual timestamps while preserving all existing data.


### Testing & verification
1. Turn the "Employee Self Correction" setting ON. (OFF by default - restricted only to employer)

![WhatsApp Image 2026-01-16 at 1 54 58 AM](https://github.com/user-attachments/assets/890668ee-a379-4e7a-8fd4-572f94a3b49d)

2. When punching in/out, select a date and time, different from current date and time.

![WhatsApp Image 2026-01-16 at 1 54 59 AM](https://github.com/user-attachments/assets/cde4faac-68b2-486d-af6b-bf5d6623a4d9)

![WhatsApp Image 2026-01-16 at 1 54 59 AM (1)](https://github.com/user-attachments/assets/73e23dff-c745-486b-a006-95ce5c272628)

3. The report shows system date-time as well as employee chosen date-time
![WhatsApp Image 2026-01-16 at 1 54 59 AM (2)](https://github.com/user-attachments/assets/23c2320f-cf39-4b76-9ac8-acf2ce966d03)